### PR TITLE
Support ingestion of attachments via email reply

### DIFF
--- a/classes/class-supportflow-email-replies.php
+++ b/classes/class-supportflow-email-replies.php
@@ -81,8 +81,9 @@ class SupportFlow_Email_Replies extends SupportFlow {
 				continue;
 
 			if ( 'ATTACHMENT' == $email_part->disposition && in_array( $email_part->subtype, $accepted_attachments ) ) {
-				// We need to add 1 to our array key each time to get the correct email part
-				$raw_attachment_data = imap_fetchbody( $this->imap_connection, $i, $k+1 );
+				// We need to add 2 to our array key each time to get the correct email part
+				//@todo this needs more testing with different emails, should be smarter about which parts
+				$raw_attachment_data = imap_fetchbody( $this->imap_connection, $i, $k+2 );
 
 				// The raw data from imap is base64 encoded, but php-imap has us covered!
 				$attachment_data = imap_base64( $raw_attachment_data );


### PR DESCRIPTION
A good first draft at ingesting email attachments and assigning them to the proper thread and comment.

This seems to support Gmail's structure just fine, but we'll definitely need to do some more testing. Want to get smarter about which file types to support as well. I hard coded a quick array, but we can probably look to WP for accepted MIME types.

Addresses #71
