### PR TITLE
Checking if post exists before accessing its properities

### DIFF
--- a/classes/class-supportflow-admin.php
+++ b/classes/class-supportflow-admin.php
@@ -984,8 +984,7 @@ class SupportFlow_Admin extends SupportFlow {
 			return $pagenow;
 		} elseif ( 'post.php' == $pagenow && ! empty( $_GET['action'] ) && 'edit' == $_GET['action'] && ! empty( $_GET['post'] ) ) {
 			$the_post = get_post( $_GET['post'] );
-
-			return ( $the_post->post_type == SupportFlow()->post_type ) ? $pagenow : false;
+			return (  $the_post != null && $the_post->post_type == SupportFlow()->post_type ) ? $pagenow : false;
 		} else {
 			return false;
 		}


### PR DESCRIPTION
Currently if you view an non-existing thread e.g.
/wp-admin/post.php?post=25456&action=edit `$the_post` returns null causing
an error

So this commits check if it is null before continuing
